### PR TITLE
Misc changes to get the mosart test case working

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -65,7 +65,7 @@ def _create_control_files(case, confdir, inst_string, infile, nmlgen, ctl, data_
        varname_downSegId = "Tosegment"
        varname_pfafCode = "PFAF"
     elif (  config['rof_grid'] == "r05" ):
-       fname_ntopOld = "ntopo_r05_MOSART_Global_half_20161105a_c20200323.nc"
+       fname_ntopOld = "ntopo_r05_MOSART_Global_half_20161105a_reord_c20200331.nc"
        varname_area = "hruArea"
        varname_length = "rlen"
        varname_slope  = "rslp"

--- a/cime_config/testdefs/testmods_dirs/mizuroute/default/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/mizuroute/default/shell_commands
@@ -1,4 +1,8 @@
 #!/bin/bash
 
 ./xmlchange ROF_NCPL="1"
+ROF_GRID=`./xmlquery --value ROF_GRID`
+if [ "$ROF_GRID" == "r05" ]; then
+   ./xmlchange ROF_DOMAIN_MESH="$DIN_LOC_ROOT/rof/mizuRoute/meshes/r05_noocean_c110308_cdf5_ESMFmesh_c20200416.nc"
+fi
 

--- a/cime_config/testdefs/testmods_dirs/mizuroute/default/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/mizuroute/default/user_nl_clm
@@ -1,0 +1,3 @@
+! Have some history output from CLM
+hist_nhtfrq = 1
+hist_mfilt = 1

--- a/route/build/cpl/nuopc/rof_comp_nuopc.F90
+++ b/route/build/cpl/nuopc/rof_comp_nuopc.F90
@@ -60,8 +60,12 @@ module rof_comp_nuopc
   integer                 :: flds_scalar_index_nx = 0
   integer                 :: flds_scalar_index_ny = 0
   integer                 :: flds_scalar_index_nextsw_cday = 0._r8
+!#ifdef NDEBUG
+  logical, parameter      :: debug_write = .true.
+!#else
+  !logical, parameter      :: debug_write = .false.
+!#endif
 
-  integer     , parameter :: debug = 1
   character(*), parameter :: modName =  "(rof_comp_nuopc)"
   character(*), parameter :: u_FILE_u = &
        __FILE__
@@ -180,7 +184,7 @@ contains
     call get_mpi_omp(mpicom)
 
 !! WHAT IS THIS? ROFID need for mizuRoute??
-!    ! Set ROFID - needed for the mosart code that requires MCT
+!    ! Set ROFID - needed for the mizuRoute code that requires MCT
 !    call NUOPC_CompAttributeGet(gcomp, name='MCTID', value=cvalue, rc=rc)
 !    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 !    read(cvalue,*) ROFID  ! convert from string to integer
@@ -276,6 +280,10 @@ contains
 
   subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
 
+#ifdef __INTEL_COMPILER
+    use IFPORT, only : qsort              ! Intel library with qsort
+#endif
+    use RtmFileUtils, only : getavu, relavu, opnfil
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
     type(ESMF_State)     :: importState
@@ -284,7 +292,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    type(ESMF_Mesh)             :: Emesh, EMeshTemp
+    type(ESMF_Mesh)             :: Emesh
     type(ESMF_DistGrid)         :: DistGrid              ! esmf global index space descriptor
     type(ESMF_Time)             :: currTime              ! Current time
     type(ESMF_Time)             :: startTime             ! Start time
@@ -323,6 +331,23 @@ contains
     logical                     :: brnch_retain_casename ! flag if should retain the case name on a branch start type
     character(len=CL)           :: cvalue
     character(ESMF_MAXSTR)      :: convCIM, purpComp
+    integer                     :: parametricDim         ! ESMF Mesh parametic dimension
+    integer                     :: spatialDim            ! ESMF Mesh spatial dimension
+    integer                     :: numOwnedNodes         ! ESMF Mesh number of owned nodes
+    integer                     :: numOwnedElements      ! ESMF Mesh number of owned elements
+    logical                     :: isMemFreed            ! ESMF Mesh if memory is freed or not
+    integer                     :: dimCount              ! ESMF dist-grid dimension count
+    integer                     :: tileCount             ! ESMF dist-grid tile count
+    integer                     :: deCount               ! ESMF dist-grid processor element count
+    integer                     :: localDeCount          ! ESMF dist-grid local processor element count
+    logical                     :: regDecompFlag         ! ESMF dist-grid regular decomposition flag
+    integer                     :: connectionCount       ! ESMF dist-grid connection count
+    integer                     :: ilog                  ! Unit to write gindex to
+    character(len=256)          :: filename              ! filename to write gindex to
+
+#ifdef __INTEL_COMPILER
+    integer(2), external        :: compare_int           ! Function to compare integers for sorting
+#endif
     character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
     !---------------------------------------------------------------------------
 
@@ -434,7 +459,7 @@ contains
     ! Read namelist, grid and surface data
     !----------------------
 
-    if (masterproc) then
+    if (masterproc .and. debug_write) then
        write(iulog,*) "mizuRoute initialization"
        write(iulog,*) ' mizuRoute npes = ',npes
        write(iulog,*) ' mizuRoute iam  = ',iam
@@ -493,32 +518,80 @@ contains
        gindex(ni) = rtmCTL%gindex(n)
     end do
 
+    if ( .not. allocated(gindex) )then
+       cmessage = cmessage // " gindex is not allocated"
+       return
+    end if
+    if ( debug_write ) then
+       write(iulog,*) "iam, lsize = ", iam, lsize
+       write(iulog,*) "iam, gindex(min,max,mid) = ", iam, minval(gindex), maxval(gindex), gindex(lsize/2)
+       call shr_sys_flush(iulog)
+    end if
+    ! Sort the indices (should NOT be required)
+#ifdef __INTEL_COMPILER
+    !call qsort( gindex, lsize, sizeof(gindex(1)), compare_int )
+#endif
+    ! Write the indices out to make sure they aren't duplicated accross tasks
+    if ( debug_write ) then
+       ilog = getavu()
+       write(filename,'(a,i3.3)') "gindex.", iam
+       call opnfil( filename, ilog, "f" )
+       do ni = 1, lsize
+          write(ilog,*) gindex(ni)
+       end do
+       call relavu(ilog)
+    end if
     ! create distGrid from global index array
     DistGrid = ESMF_DistGridCreate(arbSeqIndexList=gindex, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     deallocate(gindex)
+    if ( .not. ESMF_DistGridIsCreated( DistGrid, rc=rc ) )then
+       cmessage = cmessage // " DistGrid is NOT created"
+       return
+    end if
+    call ESMF_DistGridValidate( DistGrid, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    ! Get global dist grid attributes
+    call ESMF_DistGridGet( DistGrid, dimCount=dimCount, tileCount=tileCount, deCount=deCount, localDeCount=localDeCount, &
+     regDecompFlag=regDecompFlag, connectionCount=connectionCount, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (masterproc .and. debug_write) then
+       write(iulog,*) "dimCount = ", dimCount
+       write(iulog,*) "tileCount = ", tileCount
+       write(iulog,*) "deCount = ", deCount
+       write(iulog,*) "localDeCount = ", localDeCount
+       write(iulog,*) "connectionCount = ", connectionCount
+       write(iulog,*) "regDecompFlag = ", regDecompFlag
+       call shr_sys_flush(iulog)
+    end if
 
     ! read in the mesh
     call NUOPC_CompAttributeGet(gcomp, name='mesh_rof', value=cvalue, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-if (masterproc) then
-write(iulog,*)'cvalue= ',trim(cvalue)
-endif
-    EMeshTemp = ESMF_MeshCreate(filename=trim(cvalue), fileformat=ESMF_FILEFORMAT_ESMFMESH, rc=rc)
-if (masterproc) then
-write(iulog,*)'EMeshTemp '
-write(iulog,*)'rc ',rc
-endif
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (masterproc) then
        write(iulog,*)'mesh file for domain is ',trim(cvalue)
        call shr_sys_flush(iulog)
     end if
 
-    ! recreate the mesh using the above distGrid
-    EMesh = ESMF_MeshCreate(EMeshTemp, elementDistgrid=Distgrid, rc=rc)
+    ! Create the mesh in one step using the above distGrid
+    EMesh = ESMF_MeshCreate(filename=trim(cvalue), fileformat=ESMF_FILEFORMAT_ESMFMESH, elementDistgrid=Distgrid, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if ( debug_write )then
+       write(iulog,*) ' After ESMF_MeshCreate'
+       call shr_sys_flush(iulog)
+    end if
+    call ESMF_MeshGet( EMesh,  parametricDim=parametricDim, spatialDim=spatialDim, numOwnedNodes=numOwnedNodes, &
+                       numOwnedElements=numOwnedElements, isMemFreed=isMemFreed, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if ( debug_write )then
+       write(iulog,*) ' parametricDim = ', parametricDim
+       write(iulog,*) ' spatialDim = ', spatialDim
+       write(iulog,*) ' numOwnedNodes = ', numOwnedNodes
+       write(iulog,*) ' numOwnedElements = ', numOwnedElements
+       write(iulog,*) ' isMemFreed = ', isMemFreed
+       call shr_sys_flush(iulog)
+    end if
 
     !--------------------------------
     ! realize actively coupled fields
@@ -555,7 +628,7 @@ endif
     ! diagnostics
     !--------------------------------
 
-    if (debug > 1) then
+    if (debug_write)then
        call State_diagnose(exportState,subname//':ES',rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
@@ -733,7 +806,7 @@ endif
     ! diagnostics
     !--------------------------------
 
-    if (debug > 1) then
+    if (debug_write)then
        call State_diagnose(exportState,subname//':ES',rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
     end if
@@ -918,3 +991,24 @@ endif
   !===============================================================================
 
 end module rof_comp_nuopc
+
+  !===============================================================================
+
+#ifdef __INTEL_COMPILER
+integer(2) function compare_int( a1, a2 )
+  !
+  ! Compare two integer for sorting
+  !
+  integer, intent(IN) :: a1, a2   ! Two integers to compare for sorting
+  !-------------------------------------------------------------------------------
+  !===============================================================================
+  if ( a1 == a2 )then
+    compare_int = 0
+  else if ( a1 < a2 )then
+    compare_int = -1
+  else
+    compare_int = 1
+  end if
+  !===============================================================================
+end function compare_int
+#endif

--- a/route/build/src/domain_decomposition.f90
+++ b/route/build/src/domain_decomposition.f90
@@ -39,7 +39,7 @@ CONTAINS
    ! External modules
    USE globalData, ONLY: domains                 ! domain data structure - for each domain, pfaf codes and list of segment indices
    USE globalData, ONLY: nDomain                 ! count of decomposed domains (tributaries + mainstems)
-   USE mpi_mod,    ONLY: shr_mpi_abort
+   USE mpi_mod,    ONLY: shr_mpi_abort, shr_mpi_initialized
 
    implicit none
    ! Input variables
@@ -53,10 +53,14 @@ CONTAINS
    ! Local variables
    character(len=strLen)                       :: cmessage        ! error message from subroutine
    logical(lgt)                                :: debug = .false. ! print out reach info with node assignment for debugging
+   logical                                     :: mpi_on          ! If MPI is on
 
    ierr=0; message='mpi_domain_decomposition/'
 
-   if (nNodes==1) return
+   if (nNodes==1) then
+      call shr_mpi_initialized( mpi_on, trim(message)//"trougle checking if mpi initialized")
+      if ( .not. mpi_on ) return
+   end if
 
    call classify_river_basin(nNodes,         &        ! input:  number of procs
                              nSeg,           &        ! input:  number of reaches in the entire river network


### PR DESCRIPTION
Use the reordered ntopo file for mosart.

This gets the mosart test case roughly working for
a low PE count (as long as the right ESMF mesh is used).

Get ix1, ix2 and indices correct for different task counts.

Change some references from mosart to mizuroute. Add some
diagnostic info. on the ESMF DistGrid and Mesh that's created.
Change debug variable to debug_write. Also change the ESMF_Mesh
create into one call rather than two, like the latest MOSART.
Add some shr_sys_flush calls so output is flushed after being
done.

Some changes that get it closer for the single task MPI case to
work. Check if mpi is initialized and if it is, keep going for
some cases when it would return.

Make sure volr and flood is just set to zero, as these
are unneeded now.

Also added a quick-sort for intel for gindex which turns out is
not needed.